### PR TITLE
add support one record query

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -1,5 +1,10 @@
 package pocketbase
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 type Collection[T any] struct {
 	*Client
 	Name string
@@ -27,4 +32,35 @@ func (c Collection[T]) List(params ParamsList) (ResponseList[T], error) {
 
 	_, err := c.Client.List(c.Name, params)
 	return response, err
+}
+
+func (c Collection[T]) One(id string) (T, error) {
+	var response T
+
+	if err := c.Authorize(); err != nil {
+		return response, err
+	}
+
+	request := c.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetPathParam("collection", c.Name).
+		SetPathParam("id", id)
+
+	resp, err := request.Get(c.url + "/api/collections/{collection}/records/{id}")
+	if err != nil {
+		return response, fmt.Errorf("[one] can't send update request to pocketbase, err %w", err)
+	}
+
+	if resp.IsError() {
+		return response, fmt.Errorf("[one] pocketbase returned status: %d, msg: %s, err %w",
+			resp.StatusCode(),
+			resp.String(),
+			ErrInvalidResponse,
+		)
+	}
+
+	if err := json.Unmarshal(resp.Body(), &response); err != nil {
+		return response, fmt.Errorf("[one] can't unmarshal response, err %w", err)
+	}
+	return response, nil
 }

--- a/collection_test.go
+++ b/collection_test.go
@@ -185,3 +185,36 @@ func TestCollection_Create(t *testing.T) {
 		})
 	}
 }
+
+func TestCollection_One(t *testing.T) {
+	client := NewClient(defaultURL)
+	field := "value_" + time.Now().Format(time.StampMilli)
+	collection := Collection[map[string]any]{client, migrations.PostsPublic}
+
+	// update non-existing item
+	_, err := collection.One("non_existing_id")
+	assert.Error(t, err)
+
+	// create temporary item
+	resultCreated, err := collection.Create(map[string]any{
+		"field": field,
+	})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, resultCreated.ID)
+
+	// confirm item exists
+	item, err := collection.One(resultCreated.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, field, item["field"])
+
+	// update temporary item
+	err = collection.Update(resultCreated.ID, map[string]any{
+		"field": field + "_updated",
+	})
+	assert.NoError(t, err)
+
+	// confirm changes
+	item, err = collection.One(resultCreated.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, field+"_updated", item["field"])
+}


### PR DESCRIPTION
maybe the client api is also need support one, but I am not sure should i do. 
add support one record query is easy with the below code
```go
// client.go
func (c *Client) One(collection string, id string) (map[string]any, error) {
	return (Collection[map[string]any]{c, collection}).One(id)
}
```
