### PR TITLE
add param expand support

### DIFF
--- a/client.go
+++ b/client.go
@@ -166,6 +166,9 @@ func (c *Client) List(collection string, params ParamsList) (ResponseList[map[st
 	if params.Sort != "" {
 		request.SetQueryParam("sort", params.Sort)
 	}
+	if params.Expand != "" {
+		request.SetQueryParam("expand", params.Expand)
+	}
 
 	resp, err := request.Get(c.url + "/api/collections/{collection}/records")
 	if err != nil {

--- a/collection_test.go
+++ b/collection_test.go
@@ -57,7 +57,7 @@ func TestCollection_List(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			collection := Collection[map[string]any]{tt.client, tt.collection}
+			collection := CollectionSet[map[string]any](tt.client, tt.collection)
 			got, err := collection.List(tt.params)
 			assert.Equal(t, tt.wantErr, err != nil, err)
 			assert.Equal(t, tt.wantResult, got.TotalItems > 0)
@@ -68,7 +68,7 @@ func TestCollection_List(t *testing.T) {
 func TestCollection_Delete(t *testing.T) {
 	client := NewClient(defaultURL)
 	field := "value_" + time.Now().Format(time.StampMilli)
-	collection := Collection[map[string]any]{client, migrations.PostsPublic}
+	collection := CollectionSet[map[string]any](client, migrations.PostsPublic)
 
 	// delete non-existing item
 	err := collection.Delete("non_existing_id")
@@ -99,7 +99,7 @@ func TestCollection_Delete(t *testing.T) {
 func TestCollection_Update(t *testing.T) {
 	client := NewClient(defaultURL)
 	field := "value_" + time.Now().Format(time.StampMilli)
-	collection := Collection[map[string]any]{client, migrations.PostsPublic}
+	collection := CollectionSet[map[string]any](client, migrations.PostsPublic)
 
 	// update non-existing item
 	err := collection.Update("non_existing_id", map[string]any{
@@ -178,7 +178,7 @@ func TestCollection_Create(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			collection := Collection[any]{tt.client, tt.collection}
+			collection := CollectionSet[any](tt.client, tt.collection)
 			r, err := collection.Create(tt.body)
 			assert.Equal(t, tt.wantErr, err != nil, err)
 			assert.Equal(t, tt.wantID, r.ID != "")
@@ -189,7 +189,7 @@ func TestCollection_Create(t *testing.T) {
 func TestCollection_One(t *testing.T) {
 	client := NewClient(defaultURL)
 	field := "value_" + time.Now().Format(time.StampMilli)
-	collection := Collection[map[string]any]{client, migrations.PostsPublic}
+	collection := CollectionSet[map[string]any](client, migrations.PostsPublic)
 
 	// update non-existing item
 	_, err := collection.One("non_existing_id")

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pocketbase/dbx v1.8.0
 	github.com/pocketbase/pocketbase v0.10.2
-	github.com/r3labs/sse/v2 v2.9.0
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/multierr v1.9.0
 	golang.org/x/sync v0.1.0

--- a/params.go
+++ b/params.go
@@ -5,6 +5,7 @@ type ParamsList struct {
 	Size    int
 	Filters string
 	Sort    string
+	Expand  string
 
 	hackResponseRef any //hack for collection list
 }

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -15,7 +15,7 @@ func TestCollection_Subscribe(t *testing.T) {
 	defaultBody := map[string]interface{}{
 		"field": "value_" + time.Now().Format(time.StampMilli),
 	}
-	collection := Collection[map[string]any]{client, migrations.PostsPublic}
+	collection := CollectionSet[map[string]any](client, migrations.PostsPublic)
 	stream, err := collection.Subscribe()
 	if err != nil {
 		t.Error(err)
@@ -80,7 +80,7 @@ func TestCollection_Unsubscribe(t *testing.T) {
 	defaultBody := map[string]interface{}{
 		"field": "value_" + time.Now().Format(time.StampMilli),
 	}
-	collection := Collection[map[string]any]{client, migrations.PostsPublic}
+	collection := CollectionSet[map[string]any](client, migrations.PostsPublic)
 	stream, err := collection.Subscribe()
 	if err != nil {
 		t.Error(err)
@@ -131,7 +131,7 @@ func TestCollection_RealtimeReconnect(t *testing.T) {
 	defaultBody := map[string]interface{}{
 		"field": "value_" + time.Now().Format(time.StampMilli),
 	}
-	collection := Collection[map[string]any]{client, migrations.PostsPublic}
+	collection := CollectionSet[map[string]any](client, migrations.PostsPublic)
 	stream, err := collection.Subscribe()
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
the usage example 

```go
package main

import "github.com/r--w/pocketbase"

type User struct{}
type Comment struct {
	User string `json:"user,omitempty"` // user realtion id
}
type CommentWithExpand struct {
	Comment
	Expand *CommentExpand `json:"expand,omitempty" pbex:"user"` // pbex tag is the expand params. (another good tag name?)
}
type CommentExpand struct {
	User *User `json:"user,omitempty"`
}

func main() {
	var c1 pocketbase.Collection[CommentWithExpand] // all is type safe
	item, _ := c1.One("")
	_ = item.Expand.User

	var c2 pocketbase.Collection[Comment] // you can use anthoer collection to query without expand params
	item2, _ := c2.One("")
	_ = item2.User
}

```